### PR TITLE
fix: (IntegrationTest) add waiting after generate().

### DIFF
--- a/integration_tests/__tests__/dlctests.spec.ts
+++ b/integration_tests/__tests__/dlctests.spec.ts
@@ -135,6 +135,7 @@ beforeAll(async () => {
 
 describe("dlc tests", () => {
   it("test full execution", async () => {
+    jest.setTimeout(30000);
 
     const winAmount = 9990000;
     const loseAmount = 10000;
@@ -256,7 +257,7 @@ describe("dlc tests", () => {
       fundTxId, fundTx.vout[0].value,
       aliceFundPrivkey,
       bobFundPrivkey);
-    const cet = DecodeRawTransaction(fundTxHex);
+    const cet = DecodeRawTransaction(cetHex);
 
     const cetId = await aliceWallet.sendRawTransaction(cetHex);
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,13 @@
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
+  transform: {
+    "^.+\\.ts$": 'ts-jest'
+  },
+  globals: {
+    "ts-jest": {
+      tsConfig: 'tsconfig.json',
+    },
+  },
+  testMatch: [
+    "**/integration_tests/__tests__/*.spec.ts"
+  ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2365,8 +2365,8 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "cfd-js": {
-      "version": "git+https://github.com/cryptogarageinc/cfd-js.git#c11288d5a62f7af9fbff88809fc18765004a5db7",
-      "from": "git+https://github.com/cryptogarageinc/cfd-js.git#v0.0.17",
+      "version": "git+https://github.com/cryptogarageinc/cfd-js.git#25bfeb4b88a313887d16ded3dedc68916392009e",
+      "from": "git+https://github.com/cryptogarageinc/cfd-js.git#v0.0.21",
       "dev": true,
       "requires": {
         "@types/node": "^13.7.0",
@@ -8999,11 +8999,11 @@
       }
     },
     "wallet-for-testing-js": {
-      "version": "git+https://github.com/cryptogarageinc/wallet-for-testing-js.git#b932ba652925cfe864a716e9dee52fbba26e61aa",
-      "from": "git+https://github.com/cryptogarageinc/wallet-for-testing-js.git#v0.0.2",
+      "version": "git+https://github.com/cryptogarageinc/wallet-for-testing-js.git#ad02dff266bec69c120ffab7008617b6fe814e18",
+      "from": "git+https://github.com/cryptogarageinc/wallet-for-testing-js.git#v0.0.1",
       "dev": true,
       "requires": {
-        "cfd-js": "git+https://github.com/cryptogarageinc/cfd-js.git#v0.0.17",
+        "cfd-js": "git+https://github.com/cryptogarageinc/cfd-js.git#v0.0.21",
         "ini": "*",
         "nedb-promises": "^4.0.1",
         "node-json-rpc2": "git+https://github.com/ko-matsu/node-json-rpc2.git#async_minimum"


### PR DESCRIPTION
About the bug of Integration Test.
The cause seems to be that the block generation after executing generate() is delayed. This is a timing bug in wallet-for-testing-js. (Originally, it is necessary to wait for the reflection of Block when calling forceUpdateUtxoData.)
I don't know why yet, so let the test add wait processing.

In addition, it fixes an issue with subsequent tests and a problem with jest timeouts.