### PR TITLE
feat: replace to testing-wallet (old: replace to cfd-js-wasm)

### DIFF
--- a/integration_tests/__tests__/dlctests.spec.ts
+++ b/integration_tests/__tests__/dlctests.spec.ts
@@ -3,7 +3,7 @@ import * as CfdUtils from "../../wrap_js/cfd_utils";
 import { DlcTestHelper } from "./test_helper";
 import { DlcWalletHelper } from "./wallet_helper";
 
-const SyncTimeout = 5000;
+const SyncTimeout = 1000;
 
 jest.setTimeout(50000);
 const walletHelper = new DlcWalletHelper();

--- a/integration_tests/__tests__/wallet_helper.ts
+++ b/integration_tests/__tests__/wallet_helper.ts
@@ -44,9 +44,9 @@ export class DlcWalletHelper {
       this.configFilePath,
       dbDir,
       this.network,
-      this.testSeed
     );
-    this.walletMgr.initialize("bitcoin");
+    await this.walletMgr.setMasterPrivkey(this.testSeed);
+    await this.walletMgr.initialize("bitcoin");
 
     this.aliceWallet = await this.walletMgr.createWallet(1, "alice", "bitcoin");
     this.bobWallet = await this.walletMgr.createWallet(2, "bob", "bitcoin");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cfd-dlc-js",
-  "version": "0.0.4",
+  "version": "0.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3053,6 +3053,14 @@
         "run-script-os": "^1.1.1",
         "tape": "^4.13.2",
         "unzipper": "^0.8.14"
+      }
+    },
+    "cfd-js-wasm": {
+      "version": "github:cryptogarageinc/cfd-js-wasm#a5ab24412f915285ef3c5d18b3c848c904bad8a6",
+      "from": "github:cryptogarageinc/cfd-js-wasm#semver:^0.1.9",
+      "dev": true,
+      "requires": {
+        "@types/node": "^13.11.0"
       }
     },
     "chainsaw": {
@@ -7728,9 +7736,9 @@
       }
     },
     "localforage": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.7.4.tgz",
-      "integrity": "sha512-3EmVZatmNVeCo/t6Te7P06h2alGwbq8wXlSkcSXMvDE2/edPmsVqTPlzGnZaqwZZDBs6v+kxWpqjVsqsNJT8jA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.9.0.tgz",
+      "integrity": "sha512-rR1oyNrKulpe+VM9cYmcFn6tsHuokyVHFaCM3+osEmxaHTbEk8oQu6eGDfS6DQLWi/N67XRmB8ECG37OES368g==",
       "dev": true,
       "requires": {
         "lie": "3.1.1"
@@ -8166,18 +8174,18 @@
       }
     },
     "nedb-promises": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/nedb-promises/-/nedb-promises-4.0.3.tgz",
-      "integrity": "sha512-NzepLVjy/Vgl5lvlhO6nze2O4GsPUroONP97fRZKPlIbjt6dV7Y5CXMmPQBI6H3Q6whG8kubFOQXJkMAXIUF3w==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/nedb-promises/-/nedb-promises-4.0.4.tgz",
+      "integrity": "sha512-+z5kzrNOW0rDA1FiCfAtPGR7ZW3mnaOrYZytGAT0TbL6EqoEJUCxAuu9VME4+B1yZNG1gBx61F0c0jcacq1EsQ==",
       "dev": true,
       "requires": {
         "nedb": "^1.8.0"
       }
     },
     "needle": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.0.tgz",
-      "integrity": "sha512-o/qITSDR0JCyCKEQ1/1bnUXMmznxabbwi/Y4WwJElf+evwJNFNwIDMCCt5IigFVxgeGBJESLohGtIS9gEzo1fA==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.2.tgz",
+      "integrity": "sha512-LbRIwS9BfkPvNwNHlsA41Q29kL2L/6VaOJ0qisM5lLWsTV3nP15abO5ITL6L81zqFhzjRKDAYjpcBcwM0AVvLQ==",
       "dev": true,
       "requires": {
         "debug": "^3.2.6",
@@ -11921,17 +11929,17 @@
       }
     },
     "wallet-for-testing-js": {
-      "version": "git+https://github.com/cryptogarageinc/wallet-for-testing-js.git#774a2bdd75d2f7848325976fe5236d429f08519c",
-      "from": "git+https://github.com/cryptogarageinc/wallet-for-testing-js.git#v0.0.9",
+      "version": "git+https://github.com/cryptogarageinc/wallet-for-testing-js.git#caccfa34ec0e5d86004c8575f535f139946b7dd7",
+      "from": "git+https://github.com/cryptogarageinc/wallet-for-testing-js.git#v0.1.1",
       "dev": true,
       "requires": {
-        "cfd-js": "github:cryptogarageinc/cfd-js#v0.1.9",
-        "ini": "*",
-        "nedb-promises": "^4.0.1",
+        "cfd-js-wasm": "github:cryptogarageinc/cfd-js-wasm#semver:^0.1.9",
+        "ini": "^1.3.5",
+        "nedb-promises": "^4.0.3",
         "needle": "^2.5.0",
         "node-json-rpc2": "git+https://github.com/ko-matsu/node-json-rpc2.git#async_minimum",
-        "readline-sync": "*",
-        "zlib": "*"
+        "readline-sync": "^1.4.10",
+        "zlib": "^1.0.5"
       }
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -124,6 +124,6 @@
     "tslint": "^6.1.1",
     "tslint-plugin-prettier": "^2.3.0",
     "typescript": "^3.8.3",
-    "wallet-for-testing-js": "git+https://github.com/cryptogarageinc/wallet-for-testing-js#v0.0.12"
+    "wallet-for-testing-js": "git+https://github.com/cryptogarageinc/wallet-for-testing-js#v0.1.1"
   }
 }


### PR DESCRIPTION
This is a fix to replace cfd-js with cfd-js-wasm.
With this fix, cfd-dlc-js removes the cfd/cfd-core/libwally-core dependency.
The modifications are as follows:
1. Replace cfd-js with cfd-js-wasm.
2. Changed CfdUtils and related processes to async (because cfd-js-wasm uses async).
3. Changed test to Promise input. (Generate and acquire the set value immediately before the test)
4. Replace integration test with wallet-for-testing that supports wasm.

Since the correction in step 3 is large (but simple), please confirm if this proposal is correct. :pray:
