### PR TITLE
Enable sharing classes across request/response in code gen

### DIFF
--- a/include/cfddlcjs/cfddlcjs_struct.h
+++ b/include/cfddlcjs/cfddlcjs_struct.h
@@ -279,24 +279,12 @@ struct CreateDlcTransactionsResponseStruct {
 };
 
 // ------------------------------------------------------------------------
-// TxInRequestAStruct
+// TxOutRequestStruct
 // ------------------------------------------------------------------------
 /**
- * @brief TxInRequestAStruct struct
+ * @brief TxOutRequestStruct struct
  */
-struct TxInRequestAStruct {
-  std::string txid = "";  //!< txid  // NOLINT
-  uint32_t vout = 0;      //!< vout  // NOLINT
-  std::set<std::string> ignore_items;   //!< using on JSON mapping convert.
-};
-
-// ------------------------------------------------------------------------
-// TxOutRequestAStruct
-// ------------------------------------------------------------------------
-/**
- * @brief TxOutRequestAStruct struct
- */
-struct TxOutRequestAStruct {
+struct TxOutRequestStruct {
   uint64_t amount = 0;       //!< amount  // NOLINT
   std::string address = "";  //!< address  // NOLINT
   std::set<std::string> ignore_items;   //!< using on JSON mapping convert.
@@ -309,16 +297,16 @@ struct TxOutRequestAStruct {
  * @brief CreateFundTransactionRequestStruct struct
  */
 struct CreateFundTransactionRequestStruct {
-  std::string local_pubkey = "";                  //!< local_pubkey  // NOLINT
-  std::string remote_pubkey = "";                 //!< remote_pubkey  // NOLINT
-  uint64_t output_amount = 0;                     //!< output_amount  // NOLINT
-  std::vector<TxInRequestAStruct> local_inputs;   //!< local_inputs  // NOLINT
-  TxOutRequestAStruct local_change;               //!< local_change  // NOLINT
-  std::vector<TxInRequestAStruct> remote_inputs;  //!< remote_inputs  // NOLINT
-  TxOutRequestAStruct remote_change;              //!< remote_change  // NOLINT
-  int64_t fee_rate = 1;                           //!< fee_rate  // NOLINT
-  std::string option_dest = "";                   //!< option_dest  // NOLINT
-  uint64_t option_premium = 0;                    //!< option_premium  // NOLINT
+  std::string local_pubkey = "";                 //!< local_pubkey  // NOLINT
+  std::string remote_pubkey = "";                //!< remote_pubkey  // NOLINT
+  uint64_t output_amount = 0;                    //!< output_amount  // NOLINT
+  std::vector<TxInRequestStruct> local_inputs;   //!< local_inputs  // NOLINT
+  TxOutRequestStruct local_change;               //!< local_change  // NOLINT
+  std::vector<TxInRequestStruct> remote_inputs;  //!< remote_inputs  // NOLINT
+  TxOutRequestStruct remote_change;              //!< remote_change  // NOLINT
+  int64_t fee_rate = 1;                          //!< fee_rate  // NOLINT
+  std::string option_dest = "";                  //!< option_dest  // NOLINT
+  uint64_t option_premium = 0;                   //!< option_premium  // NOLINT
   std::set<std::string> ignore_items;   //!< using on JSON mapping convert.
 };
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -130,22 +130,22 @@ export interface CreateDlcTransactionsResponse {
     refundTxHex: string;
 }
 
-export interface TxInRequestA {
+export interface TxInRequest {
     txid: string;
     vout: number;
 }
 
-export interface TxOutRequestA {
+export interface TxOutRequest {
     amount: bigint | number;
     address: string;
 }
 
-export interface TxInRequestA {
+export interface TxInRequest {
     txid: string;
     vout: number;
 }
 
-export interface TxOutRequestA {
+export interface TxOutRequest {
     amount: bigint | number;
     address: string;
 }
@@ -154,10 +154,10 @@ export interface CreateFundTransactionRequest {
     localPubkey: string;
     remotePubkey: string;
     outputAmount: bigint | number;
-    localInputs: TxInRequestA[];
-    localChange: TxOutRequestA;
-    remoteInputs: TxInRequestA[];
-    remoteChange: TxOutRequestA;
+    localInputs: TxInRequest[];
+    localChange: TxOutRequest;
+    remoteInputs: TxInRequest[];
+    remoteChange: TxOutRequest;
     feeRate: bigint | number;
     optionDest?: string;
     optionPremium?: bigint | number;

--- a/src/autogen/cfd_dlc_js_api_json_autogen.cpp
+++ b/src/autogen/cfd_dlc_js_api_json_autogen.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 CryptoGarage
+// Copyright 2020 CryptoGarage
 /**
  * @file cfd_dlc_js_api_json_autogen.cpp
  *
@@ -1151,87 +1151,43 @@ CreateDlcTransactionsResponseStruct CreateDlcTransactionsResponse::ConvertToStru
 }
 
 // ------------------------------------------------------------------------
-// TxInRequestA
+// TxOutRequest
 // ------------------------------------------------------------------------
-cfd::core::JsonTableMap<TxInRequestA>
-  TxInRequestA::json_mapper;
-std::vector<std::string> TxInRequestA::item_list;
+cfd::core::JsonTableMap<TxOutRequest>
+  TxOutRequest::json_mapper;
+std::vector<std::string> TxOutRequest::item_list;
 
-void TxInRequestA::CollectFieldName() {
+void TxOutRequest::CollectFieldName() {
   if (!json_mapper.empty()) {
     return;
   }
-  cfd::core::CLASS_FUNCTION_TABLE<TxInRequestA> func_table;  // NOLINT
+  cfd::core::CLASS_FUNCTION_TABLE<TxOutRequest> func_table;  // NOLINT
 
   func_table = {
-    TxInRequestA::GetTxidString,
-    TxInRequestA::SetTxidString,
-    TxInRequestA::GetTxidFieldType,
-  };
-  json_mapper.emplace("txid", func_table);
-  item_list.push_back("txid");
-  func_table = {
-    TxInRequestA::GetVoutString,
-    TxInRequestA::SetVoutString,
-    TxInRequestA::GetVoutFieldType,
-  };
-  json_mapper.emplace("vout", func_table);
-  item_list.push_back("vout");
-}
-
-void TxInRequestA::ConvertFromStruct(
-    const TxInRequestAStruct& data) {
-  txid_ = data.txid;
-  vout_ = data.vout;
-  ignore_items = data.ignore_items;
-}
-
-TxInRequestAStruct TxInRequestA::ConvertToStruct() const {  // NOLINT
-  TxInRequestAStruct result;
-  result.txid = txid_;
-  result.vout = vout_;
-  result.ignore_items = ignore_items;
-  return result;
-}
-
-// ------------------------------------------------------------------------
-// TxOutRequestA
-// ------------------------------------------------------------------------
-cfd::core::JsonTableMap<TxOutRequestA>
-  TxOutRequestA::json_mapper;
-std::vector<std::string> TxOutRequestA::item_list;
-
-void TxOutRequestA::CollectFieldName() {
-  if (!json_mapper.empty()) {
-    return;
-  }
-  cfd::core::CLASS_FUNCTION_TABLE<TxOutRequestA> func_table;  // NOLINT
-
-  func_table = {
-    TxOutRequestA::GetAmountString,
-    TxOutRequestA::SetAmountString,
-    TxOutRequestA::GetAmountFieldType,
+    TxOutRequest::GetAmountString,
+    TxOutRequest::SetAmountString,
+    TxOutRequest::GetAmountFieldType,
   };
   json_mapper.emplace("amount", func_table);
   item_list.push_back("amount");
   func_table = {
-    TxOutRequestA::GetAddressString,
-    TxOutRequestA::SetAddressString,
-    TxOutRequestA::GetAddressFieldType,
+    TxOutRequest::GetAddressString,
+    TxOutRequest::SetAddressString,
+    TxOutRequest::GetAddressFieldType,
   };
   json_mapper.emplace("address", func_table);
   item_list.push_back("address");
 }
 
-void TxOutRequestA::ConvertFromStruct(
-    const TxOutRequestAStruct& data) {
+void TxOutRequest::ConvertFromStruct(
+    const TxOutRequestStruct& data) {
   amount_ = data.amount;
   address_ = data.address;
   ignore_items = data.ignore_items;
 }
 
-TxOutRequestAStruct TxOutRequestA::ConvertToStruct() const {  // NOLINT
-  TxOutRequestAStruct result;
+TxOutRequestStruct TxOutRequest::ConvertToStruct() const {  // NOLINT
+  TxOutRequestStruct result;
   result.amount = amount_;
   result.address = address_;
   result.ignore_items = ignore_items;

--- a/src/autogen/cfd_dlc_js_api_json_autogen.h
+++ b/src/autogen/cfd_dlc_js_api_json_autogen.h
@@ -5210,203 +5210,18 @@ class CreateDlcTransactionsResponse
 };
 
 // ------------------------------------------------------------------------
-// TxInRequestA
+// TxOutRequest
 // ------------------------------------------------------------------------
 /**
- * @brief JSON-API (TxInRequestA) class
+ * @brief JSON-API (TxOutRequest) class
  */
-class TxInRequestA
-  : public cfd::core::JsonClassBase<TxInRequestA> {
+class TxOutRequest
+  : public cfd::core::JsonClassBase<TxOutRequest> {
  public:
-  TxInRequestA() {
+  TxOutRequest() {
     CollectFieldName();
   }
-  virtual ~TxInRequestA() {
-    // do nothing
-  }
-  /**
-   * @brief collect field name.
-   */
-  static void CollectFieldName();
-
-  /**
-   * @brief Get of txid
-   * @return txid
-   */
-  std::string GetTxid() const {
-    return txid_;
-  }
-  /**
-   * @brief Set to txid
-   * @param[in] txid    setting value.
-   */
-  void SetTxid(  // line separate
-    const std::string& txid) {  // NOLINT
-    this->txid_ = txid;
-  }
-  /**
-   * @brief Get data type of txid
-   * @return Data type of txid
-   */
-  static std::string GetTxidFieldType() {
-    return "std::string";
-  }
-  /**
-   * @brief Get json string of txid field.
-   * @param[in,out] obj     class object.
-   * @return JSON string
-   */
-  static std::string GetTxidString(  // line separate
-      const TxInRequestA& obj) {  // NOLINT
-    return cfd::core::ConvertToString(obj.txid_);
-  }
-  /**
-   * @brief Set json object to txid field.
-   * @param[in,out] obj     class object.
-   * @param[in] json_value  JSON object.
-   */
-  static void SetTxidString(  // line separate
-      TxInRequestA& obj,  // NOLINT
-      const UniValue& json_value) {
-    cfd::core::ConvertFromUniValue(  // line separate
-      obj.txid_, json_value);
-  }
-
-  /**
-   * @brief Get of vout
-   * @return vout
-   */
-  uint32_t GetVout() const {
-    return vout_;
-  }
-  /**
-   * @brief Set to vout
-   * @param[in] vout    setting value.
-   */
-  void SetVout(  // line separate
-    const uint32_t& vout) {  // NOLINT
-    this->vout_ = vout;
-  }
-  /**
-   * @brief Get data type of vout
-   * @return Data type of vout
-   */
-  static std::string GetVoutFieldType() {
-    return "uint32_t";
-  }
-  /**
-   * @brief Get json string of vout field.
-   * @param[in,out] obj     class object.
-   * @return JSON string
-   */
-  static std::string GetVoutString(  // line separate
-      const TxInRequestA& obj) {  // NOLINT
-    return cfd::core::ConvertToString(obj.vout_);
-  }
-  /**
-   * @brief Set json object to vout field.
-   * @param[in,out] obj     class object.
-   * @param[in] json_value  JSON object.
-   */
-  static void SetVoutString(  // line separate
-      TxInRequestA& obj,  // NOLINT
-      const UniValue& json_value) {
-    cfd::core::ConvertFromUniValue(  // line separate
-      obj.vout_, json_value);
-  }
-
-  /**
-   * @brief Set ignore item.
-   * @param[in] key   ignore target key name.
-   */
-  void SetIgnoreItem(const std::string& key) {
-    ignore_items.insert(key);
-  }
-
-  /**
-   * @brief Convert struct to class.
-   * @param[in] data   struct data.
-   */
-  void ConvertFromStruct(
-      const TxInRequestAStruct& data);
-
-  /**
-   * @brief Convert class to struct.
-   * @return  struct data.
-   */
-  TxInRequestAStruct ConvertToStruct()  const;
-
- protected:
-  /**
-   * @brief definition type of Map table.
-   */
-  using TxInRequestAMapTable =
-    cfd::core::JsonTableMap<TxInRequestA>;
-
-  /**
-   * @brief Get JSON mapping object.
-   * @return JSON mapping object.
-   * @see cfd::core::JsonClassBase::GetJsonMapper()
-   */
-  virtual const TxInRequestAMapTable& GetJsonMapper() const {  // NOLINT
-    return json_mapper;
-  }
-  /**
-   * @brief Get item lists of JSON mapping.
-   * Fetch a list of target variable names in the order of definition.
-   * @return Item lists of JSON mapping.
-   * @see cfd::core::JsonClassBase::GetJsonItemList()
-   */
-  virtual const std::vector<std::string>& GetJsonItemList() const {
-    return item_list;
-  }
-  /**
-   * @brief Get ignore item lists of JSON mnapping.
-   * Ignore the target variable at Serialize.
-   * @return Item list of JSON mapping.
-   * @see cfd::core::JsonClassBase::GetIgnoreItem()
-   */
-  virtual const std::set<std::string>& GetIgnoreItem() const {
-    return ignore_items;
-  }
-
- private:
- /**
-  * @brief JsonFunctionMap table
-  */
-  static TxInRequestAMapTable json_mapper;
-  /**
-   * @brief field name list.
-   */
-  static std::vector<std::string> item_list;
-  /**
-   * @brief ignore item list.
-   */
-  std::set<std::string> ignore_items;
-
-  /**
-   * @brief JsonAPI(txid) value
-   */
-  std::string txid_ = "";
-  /**
-   * @brief JsonAPI(vout) value
-   */
-  uint32_t vout_ = 0;
-};
-
-// ------------------------------------------------------------------------
-// TxOutRequestA
-// ------------------------------------------------------------------------
-/**
- * @brief JSON-API (TxOutRequestA) class
- */
-class TxOutRequestA
-  : public cfd::core::JsonClassBase<TxOutRequestA> {
- public:
-  TxOutRequestA() {
-    CollectFieldName();
-  }
-  virtual ~TxOutRequestA() {
+  virtual ~TxOutRequest() {
     // do nothing
   }
   /**
@@ -5442,7 +5257,7 @@ class TxOutRequestA
    * @return JSON string
    */
   static std::string GetAmountString(  // line separate
-      const TxOutRequestA& obj) {  // NOLINT
+      const TxOutRequest& obj) {  // NOLINT
     return cfd::core::ConvertToString(obj.amount_);
   }
   /**
@@ -5451,7 +5266,7 @@ class TxOutRequestA
    * @param[in] json_value  JSON object.
    */
   static void SetAmountString(  // line separate
-      TxOutRequestA& obj,  // NOLINT
+      TxOutRequest& obj,  // NOLINT
       const UniValue& json_value) {
     cfd::core::ConvertFromUniValue(  // line separate
       obj.amount_, json_value);
@@ -5485,7 +5300,7 @@ class TxOutRequestA
    * @return JSON string
    */
   static std::string GetAddressString(  // line separate
-      const TxOutRequestA& obj) {  // NOLINT
+      const TxOutRequest& obj) {  // NOLINT
     return cfd::core::ConvertToString(obj.address_);
   }
   /**
@@ -5494,7 +5309,7 @@ class TxOutRequestA
    * @param[in] json_value  JSON object.
    */
   static void SetAddressString(  // line separate
-      TxOutRequestA& obj,  // NOLINT
+      TxOutRequest& obj,  // NOLINT
       const UniValue& json_value) {
     cfd::core::ConvertFromUniValue(  // line separate
       obj.address_, json_value);
@@ -5513,27 +5328,27 @@ class TxOutRequestA
    * @param[in] data   struct data.
    */
   void ConvertFromStruct(
-      const TxOutRequestAStruct& data);
+      const TxOutRequestStruct& data);
 
   /**
    * @brief Convert class to struct.
    * @return  struct data.
    */
-  TxOutRequestAStruct ConvertToStruct()  const;
+  TxOutRequestStruct ConvertToStruct()  const;
 
  protected:
   /**
    * @brief definition type of Map table.
    */
-  using TxOutRequestAMapTable =
-    cfd::core::JsonTableMap<TxOutRequestA>;
+  using TxOutRequestMapTable =
+    cfd::core::JsonTableMap<TxOutRequest>;
 
   /**
    * @brief Get JSON mapping object.
    * @return JSON mapping object.
    * @see cfd::core::JsonClassBase::GetJsonMapper()
    */
-  virtual const TxOutRequestAMapTable& GetJsonMapper() const {  // NOLINT
+  virtual const TxOutRequestMapTable& GetJsonMapper() const {  // NOLINT
     return json_mapper;
   }
   /**
@@ -5559,7 +5374,7 @@ class TxOutRequestA
  /**
   * @brief JsonFunctionMap table
   */
-  static TxOutRequestAMapTable json_mapper;
+  static TxOutRequestMapTable json_mapper;
   /**
    * @brief field name list.
    */
@@ -5732,7 +5547,7 @@ class CreateFundTransactionRequest
    * @brief Get of localInputs.
    * @return localInputs
    */
-  JsonObjectVector<TxInRequestA, TxInRequestAStruct>& GetLocalInputs() {  // NOLINT
+  JsonObjectVector<TxInRequest, TxInRequestStruct>& GetLocalInputs() {  // NOLINT
     return local_inputs_;
   }
   /**
@@ -5740,7 +5555,7 @@ class CreateFundTransactionRequest
    * @param[in] local_inputs    setting value.
    */
   void SetLocalInputs(  // line separate
-      const JsonObjectVector<TxInRequestA, TxInRequestAStruct>& local_inputs) {  // NOLINT
+      const JsonObjectVector<TxInRequest, TxInRequestStruct>& local_inputs) {  // NOLINT
     this->local_inputs_ = local_inputs;
   }
   /**
@@ -5748,7 +5563,7 @@ class CreateFundTransactionRequest
    * @return Data type of localInputs.
    */
   static std::string GetLocalInputsFieldType() {
-    return "JsonObjectVector<TxInRequestA, TxInRequestAStruct>";  // NOLINT
+    return "JsonObjectVector<TxInRequest, TxInRequestStruct>";  // NOLINT
   }
   /**
    * @brief Get json string of localInputs field.
@@ -5776,7 +5591,7 @@ class CreateFundTransactionRequest
    * @brief Get of localChange.
    * @return localChange
    */
-  TxOutRequestA& GetLocalChange() {  // NOLINT
+  TxOutRequest& GetLocalChange() {  // NOLINT
     return local_change_;
   }
   /**
@@ -5784,7 +5599,7 @@ class CreateFundTransactionRequest
    * @param[in] local_change    setting value.
    */
   void SetLocalChange(  // line separate
-      const TxOutRequestA& local_change) {  // NOLINT
+      const TxOutRequest& local_change) {  // NOLINT
     this->local_change_ = local_change;
   }
   /**
@@ -5792,7 +5607,7 @@ class CreateFundTransactionRequest
    * @return Data type of localChange.
    */
   static std::string GetLocalChangeFieldType() {
-    return "TxOutRequestA";  // NOLINT
+    return "TxOutRequest";  // NOLINT
   }
   /**
    * @brief Get json string of localChange field.
@@ -5820,7 +5635,7 @@ class CreateFundTransactionRequest
    * @brief Get of remoteInputs.
    * @return remoteInputs
    */
-  JsonObjectVector<TxInRequestA, TxInRequestAStruct>& GetRemoteInputs() {  // NOLINT
+  JsonObjectVector<TxInRequest, TxInRequestStruct>& GetRemoteInputs() {  // NOLINT
     return remote_inputs_;
   }
   /**
@@ -5828,7 +5643,7 @@ class CreateFundTransactionRequest
    * @param[in] remote_inputs    setting value.
    */
   void SetRemoteInputs(  // line separate
-      const JsonObjectVector<TxInRequestA, TxInRequestAStruct>& remote_inputs) {  // NOLINT
+      const JsonObjectVector<TxInRequest, TxInRequestStruct>& remote_inputs) {  // NOLINT
     this->remote_inputs_ = remote_inputs;
   }
   /**
@@ -5836,7 +5651,7 @@ class CreateFundTransactionRequest
    * @return Data type of remoteInputs.
    */
   static std::string GetRemoteInputsFieldType() {
-    return "JsonObjectVector<TxInRequestA, TxInRequestAStruct>";  // NOLINT
+    return "JsonObjectVector<TxInRequest, TxInRequestStruct>";  // NOLINT
   }
   /**
    * @brief Get json string of remoteInputs field.
@@ -5864,7 +5679,7 @@ class CreateFundTransactionRequest
    * @brief Get of remoteChange.
    * @return remoteChange
    */
-  TxOutRequestA& GetRemoteChange() {  // NOLINT
+  TxOutRequest& GetRemoteChange() {  // NOLINT
     return remote_change_;
   }
   /**
@@ -5872,7 +5687,7 @@ class CreateFundTransactionRequest
    * @param[in] remote_change    setting value.
    */
   void SetRemoteChange(  // line separate
-      const TxOutRequestA& remote_change) {  // NOLINT
+      const TxOutRequest& remote_change) {  // NOLINT
     this->remote_change_ = remote_change;
   }
   /**
@@ -5880,7 +5695,7 @@ class CreateFundTransactionRequest
    * @return Data type of remoteChange.
    */
   static std::string GetRemoteChangeFieldType() {
-    return "TxOutRequestA";  // NOLINT
+    return "TxOutRequest";  // NOLINT
   }
   /**
    * @brief Get json string of remoteChange field.
@@ -6117,19 +5932,19 @@ class CreateFundTransactionRequest
   /**
    * @brief JsonAPI(localInputs) value
    */
-  JsonObjectVector<TxInRequestA, TxInRequestAStruct> local_inputs_;  // NOLINT
+  JsonObjectVector<TxInRequest, TxInRequestStruct> local_inputs_;  // NOLINT
   /**
    * @brief JsonAPI(localChange) value
    */
-  TxOutRequestA local_change_;  // NOLINT
+  TxOutRequest local_change_;  // NOLINT
   /**
    * @brief JsonAPI(remoteInputs) value
    */
-  JsonObjectVector<TxInRequestA, TxInRequestAStruct> remote_inputs_;  // NOLINT
+  JsonObjectVector<TxInRequest, TxInRequestStruct> remote_inputs_;  // NOLINT
   /**
    * @brief JsonAPI(remoteChange) value
    */
-  TxOutRequestA remote_change_;  // NOLINT
+  TxOutRequest remote_change_;  // NOLINT
   /**
    * @brief JsonAPI(feeRate) value
    */

--- a/src/cfddlcjs_transactions.cpp
+++ b/src/cfddlcjs_transactions.cpp
@@ -64,7 +64,7 @@ CreateFundTransactionResponseStruct DlcTransactionsApi::CreateFundTransaction(
         request.option_dest == "" ? Address() : Address(request.option_dest);
 
     std::vector<TxIn> local_inputs;
-    for (TxInRequestAStruct txin_req : request.local_inputs) {
+    for (TxInRequestStruct txin_req : request.local_inputs) {
       auto txid = Txid(txin_req.txid);
       auto txin = TxIn(txid, txin_req.vout, 0);
       local_inputs.push_back(txin);
@@ -72,7 +72,7 @@ CreateFundTransactionResponseStruct DlcTransactionsApi::CreateFundTransaction(
 
     auto local_change_address = Address(request.local_change.address);
     std::vector<TxIn> remote_inputs;
-    for (TxInRequestAStruct txin_req : request.remote_inputs) {
+    for (TxInRequestStruct txin_req : request.remote_inputs) {
       auto txid = Txid(txin_req.txid);
       auto txin = TxIn(txid, txin_req.vout, 0);
       remote_inputs.push_back(txin);

--- a/src/input_json_format/cfddlcapi_create_fund_transaction.json
+++ b/src/input_json_format/cfddlcapi_create_fund_transaction.json
@@ -9,28 +9,28 @@
     "outputAmount:type": "uint64_t",
     "localInputs": [
       {
-        ":class": "TxInRequestA",
+        ":class": "TxInRequest",
         "txid": "",
         "vout": 0,
         "vout:type": "uint32_t"
       }
     ],
     "localChange": {
-      ":class": "TxOutRequestA",
+      ":class": "TxOutRequest",
       "amount": 0,
       "amount:type": "uint64_t",
       "address": ""
     },
     "remoteInputs": [
       {
-        ":class": "TxInRequestA",
+        ":class": "TxInRequest",
         "txid": "",
         "vout": 0,
         "vout:type": "uint32_t"
       }
     ],
     "remoteChange": {
-      ":class": "TxOutRequestA",
+      ":class": "TxOutRequest",
       "amount": 0,
       "amount:type": "uint64_t",
       "address": ""

--- a/tools/generate_json_map_class.js
+++ b/tools/generate_json_map_class.js
@@ -11,6 +11,9 @@ let debugLog = function () {
   // do nothing
 };
 
+let classHeaderSet = new Set();
+let classSourceSet = new Set();
+
 // ----------------------------------------------------------------------------
 // json data class
 // ----------------------------------------------------------------------------
@@ -426,7 +429,7 @@ const generateFileSource = (filename, headerName, class_list, json_setting) => {
   const include_nolint = headerName.indexOf("/") >= 0 ? "" : "  // NOLINT";
 
   // header
-  const source_file_header = `// Copyright 2019 CryptoGarage
+  const source_file_header = `// Copyright 2020 CryptoGarage
 /**
  * @file ${filename}
  *
@@ -501,7 +504,10 @@ const generateClassSource = (req, res) => {
 
       for (const map_key in map_list) {
         const map_data = map_list[map_key];
-        if (processed_list.includes(map_data.type)) {
+        if (
+          classSourceSet.has(map_data.type) ||
+          processed_list.includes(map_data.type)
+        ) {
           continue;
         }
         const source_class_header = `
@@ -593,6 +599,7 @@ void ${map_data.type}::CollectFieldName() {
           result.push("}");
         }
 
+        classSourceSet.add(map_data.type);
         processed_list.push(map_data.type);
       }
     }
@@ -956,9 +963,14 @@ const generateClassHeader = (req, res, json_setting) => {
 
       for (const map_key in map_list) {
         const map_data = map_list[map_key];
-        if (processed_list.includes(map_data.type)) {
+        console.log("TYPE:" + map_data.type);
+        if (
+          classHeaderSet.has(map_data.type) ||
+          processed_list.includes(map_data.type)
+        ) {
           continue;
         }
+
         const class_header = generateClassHeaderData(map_data, export_define);
         result.push(class_header);
 
@@ -1006,6 +1018,7 @@ const generateClassHeader = (req, res, json_setting) => {
 
         result.push("};");
 
+        classHeaderSet.add(map_data.type);
         processed_list.push(map_data.type);
       }
     }


### PR DESCRIPTION
Added a global registry of class name for the code generation so that it is possible to reuse the type names across multiple request/response types.