### PR TITLE
Update CMakeLists.txt to clone cfd-dlc from http

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -19,7 +19,7 @@ if(CFD_DLC_TARGET_URL)
 set(CFD_DLC_TARGET_REP  ${CFD_DLC_TARGET_URL})
 message(STATUS "[external project debug] cfddlc url=${CFD_DLC_TARGET_URL}")
 else()
-set(CFD_DLC_TARGET_REP  git@github.com:p2pderivatives/cfd-dlc.git)
+set(CFD_DLC_TARGET_REP  https://github.com/p2pderivatives/cfd-dlc)
 endif()
 
 set(TEMPLATE_PROJECT_NAME           cfd-dlc)


### PR DESCRIPTION
Clone https://github.com/p2pderivatives/cfd-dlc using https instead of git to avoid "could to read cfd-dlc" problem

All test are green


```bash
$ npm run test

> cfd-dlc-js@0.0.7 test /home/biteskola/blockchain/cfd-dlc-js3
> jest --no-cache

jest-haste-map: Haste module naming collision: wallyjs
  The following files share their name; please adjust your hasteImpl:
    * <rootDir>/external/libwally-core/src/wrap_js/package.json
    * <rootDir>/external/libwally-core/package.json

 PASS  wrap_js/__test__/CreateDlcTransactions.spec.ts (5.998s)
 PASS  wrap_js/__test__/VerifyCetSignatures.spec.ts (5.984s)
 PASS  wrap_js/__test__/SignClosingTransaction.spec.ts (5.993s)
 PASS  wrap_js/__test__/CreateFundTransaction.spec.ts (6.139s)
 PASS  wrap_js/__test__/GetRawCetSignatures.spec.ts (6.209s)
 PASS  wrap_js/__test__/VerifyRefundTxSignature.spec.ts (6.223s)
 PASS  wrap_js/__test__/VerifyFundTxSignature.spec.ts
 PASS  wrap_js/__test__/VerifyCetSignature.spec.ts (6.274s)
 PASS  wrap_js/__test__/CreateCet.spec.ts
 PASS  wrap_js/__test__/GetSchnorrPublicNonce.spec.ts
 PASS  wrap_js/__test__/AddSignaturesToMutualClosingTx.spec.ts
 PASS  wrap_js/__test__/AddSignaturesToRefundTx.spec.ts
 PASS  wrap_js/__test__/CreateRefundTransaction.spec.ts
 PASS  wrap_js/__test__/CreateMutualClosingTransaction.spec.ts
 PASS  wrap_js/__test__/GetRawMutualClosingTxSignature.spec.ts
 PASS  wrap_js/__test__/CreatePenaltyTransaction.spec.ts
 PASS  wrap_js/__test__/GetRawRefundTxSignature.spec.ts
 PASS  wrap_js/__test__/CreateClosingTransaction.spec.ts
 PASS  wrap_js/__test__/AddSignatureToFundTransaction.spec.ts
 PASS  wrap_js/__test__/GetRawCetSignature.spec.ts
 PASS  wrap_js/__test__/AddSignaturesToCet.spec.ts
 PASS  wrap_js/__test__/GetRawFundTxSignature.spec.ts
 PASS  wrap_js/__test__/SignFundTransaction.spec.ts
 PASS  wrap_js/__test__/SchnorrSign.spec.ts

Test Suites: 24 passed, 24 total
Tests:       34 passed, 34 total
Snapshots:   0 total
Time:        8.095s
Ran all test suites.
```

Fix #35